### PR TITLE
feat!: don't namespace public classes, dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 4.0.0 (2026-03-20)
 
 ## BREAKING CHANGES
-- Don't namespace public api classes, dedupe identical class definitions. [#7](https://github.com/blackbaud/skyux-branding-builder/pull/7)
+- Don't namespace public api classes, dedupe identical class definitions. [#8](https://github.com/blackbaud/skyux-branding-builder/pull/8)
 
 # 3.0.0 (2026-03-19)
 - Children public tokens and styles now inherit parent metadata if their metadata property is unset. [#7](https://github.com/blackbaud/skyux-branding-builder/pull/7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.0 (2026-03-20)
+
+## BREAKING CHANGES
+- Don't namespace public api classes, dedupe identical class definitions. [#7](https://github.com/blackbaud/skyux-branding-builder/pull/7)
+
 # 3.0.0 (2026-03-19)
 - Children public tokens and styles now inherit parent metadata if their metadata property is unset. [#7](https://github.com/blackbaud/skyux-branding-builder/pull/7)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-branding-builder",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-branding-builder",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "style dictionary builder for design tokens",
   "main": "index.js",
   "type": "module",

--- a/src/plugins/build-style-dictionary-plugin.mts
+++ b/src/plugins/build-style-dictionary-plugin.mts
@@ -48,9 +48,8 @@ async function generateDictionaryFiles(
 ): Promise<{
   tokenFiles: GeneratedFile[];
   publicTokenCssFiles: GeneratedFile[];
-  publicTokenJsonFiles: GeneratedFile[];
-  publicClassFiles: GeneratedFile[];
-  publicClassJsonFiles: GeneratedFile[];
+  publicTokenJsonFiles: string[];
+  publicClassJsonFiles: string[];
 }> {
   const sd = new StyleDictionary({ log: { verbosity: 'verbose' } });
   const rootPath = tokenConfig.rootPath || 'src/tokens/';
@@ -59,9 +58,8 @@ async function generateDictionaryFiles(
     tokenConfig.tokenSets.map(async (tokenSet) => {
       const tokenFiles: GeneratedFile[] = [];
       const publicTokenCssFiles: GeneratedFile[] = [];
-      const publicTokenJsonFiles: GeneratedFile[] = [];
-      const publicClassFiles: GeneratedFile[] = [];
-      const publicClassJsonFiles: GeneratedFile[] = [];
+      const publicTokenJsonFiles: string[] = [];
+      const publicClassJsonFiles: string[] = [];
 
       const tokenDictionary = await sd.extend(
         getBaseDictionaryConfig(rootPath, tokenSet, {
@@ -143,20 +141,15 @@ async function generateDictionaryFiles(
         );
         publicTokenCssFiles.push(...publicResults.flatMap((r) => r.cssFiles));
         publicTokenJsonFiles.push(
-          ...publicResults.map(
-            (r) =>
-              ({
-                output: JSON.stringify(r.docsData),
-              }) as GeneratedFile,
-          ),
+          ...publicResults.map((r) => JSON.stringify(r.docsData)),
         );
       }
 
       if (tokenSet.publicStyles?.length) {
         // Build the set of known CSS custom properties from this token set's public tokens.
         const knownCustomProperties = new Set<string>();
-        for (const file of publicTokenJsonFiles) {
-          const parsed = JSON.parse(file.output as string) as PublicApiTokens;
+        for (const json of publicTokenJsonFiles) {
+          const parsed = JSON.parse(json) as PublicApiTokens;
           collectPublicTokenCustomProperties(parsed, knownCustomProperties);
         }
 
@@ -172,30 +165,16 @@ async function generateDictionaryFiles(
               knownCustomProperties,
               publicStyleSet.name,
             );
-            return {
-              css: {
-                output: generatePublicStylesCss(
-                  publicApiStyles,
-                  tokenSet.selector,
-                ),
-                destination: `${tokenSet.name}/${publicStyleSet.name}.css`,
-              },
-              json: {
-                output: JSON.stringify(publicApiStyles),
-                destination: `${tokenSet.name}/${publicStyleSet.name}.json`,
-              },
-            };
+            return JSON.stringify(publicApiStyles);
           }),
         );
-        publicClassFiles.push(...classResults.map((r) => r.css));
-        publicClassJsonFiles.push(...classResults.map((r) => r.json));
+        publicClassJsonFiles.push(...classResults);
       }
 
       return {
         setTokenFiles: tokenFiles,
         setPublicTokenCssFiles: publicTokenCssFiles,
         setPublicTokenJsonFiles: publicTokenJsonFiles,
-        setPublicClassFiles: publicClassFiles,
         setPublicClassJsonFiles: publicClassJsonFiles,
       };
     }),
@@ -206,7 +185,6 @@ async function generateDictionaryFiles(
   const publicTokenJsonFiles = results.flatMap(
     (r) => r.setPublicTokenJsonFiles,
   );
-  const publicClassFiles = results.flatMap((r) => r.setPublicClassFiles);
   const publicClassJsonFiles = results.flatMap(
     (r) => r.setPublicClassJsonFiles,
   );
@@ -224,7 +202,6 @@ async function generateDictionaryFiles(
     tokenFiles,
     publicTokenCssFiles,
     publicTokenJsonFiles,
-    publicClassFiles,
     publicClassJsonFiles,
   };
 }
@@ -376,7 +353,6 @@ ${variables}
         tokenFiles,
         publicTokenCssFiles,
         publicTokenJsonFiles,
-        publicClassFiles,
         publicClassJsonFiles,
       } = await generateDictionaryFiles(tokenConfig, {
         assetsBasePath,
@@ -402,10 +378,21 @@ ${variables}
         }
       }
 
-      for (const file of [...publicTokenCssFiles, ...publicClassFiles]) {
+      for (const file of publicTokenCssFiles) {
         compositeFiles[publicApiFileName] =
           (compositeFiles[publicApiFileName] ?? '') +
           ((file.output as string) ?? '');
+      }
+
+      const publicApiStylesJsonData: PublicApiStyles = {};
+      for (const json of publicClassJsonFiles) {
+        const parsed = JSON.parse(json) as PublicApiStyles;
+        mergePublicApiStylesResults(publicApiStylesJsonData, parsed);
+      }
+      if (publicApiStylesJsonData.groups || publicApiStylesJsonData.styles) {
+        compositeFiles[publicApiFileName] =
+          (compositeFiles[publicApiFileName] ?? '') +
+          generatePublicStylesCss(publicApiStylesJsonData);
       }
 
       for (const fileName of Object.keys(compositeFiles)) {
@@ -423,8 +410,8 @@ ${variables}
       }
 
       const publicApiJsonData: PublicApiTokens = {};
-      for (const file of publicTokenJsonFiles) {
-        const parsed = JSON.parse(file.output as string) as PublicApiTokens;
+      for (const json of publicTokenJsonFiles) {
+        const parsed = JSON.parse(json) as PublicApiTokens;
         mergePublicApiResults(publicApiJsonData, parsed);
       }
       applyDemoMetadataInheritance(publicApiJsonData);
@@ -436,11 +423,6 @@ ${variables}
         });
       }
 
-      const publicApiStylesJsonData: PublicApiStyles = {};
-      for (const file of publicClassJsonFiles) {
-        const parsed = JSON.parse(file.output as string) as PublicApiStyles;
-        mergePublicApiStylesResults(publicApiStylesJsonData, parsed);
-      }
       if (publicApiStylesJsonData.groups || publicApiStylesJsonData.styles) {
         this.emitFile({
           type: 'asset',

--- a/src/plugins/build-style-dictionary-plugin.mts
+++ b/src/plugins/build-style-dictionary-plugin.mts
@@ -20,6 +20,7 @@ import {
 import {
   generatePublicStylesCss,
   mergePublicApiStylesResults,
+  mergePublicApiStylesResultsForCss,
   validatePublicStylesCssProperties,
 } from './shared/public-api-styles-utils.mjs';
 import {
@@ -336,12 +337,14 @@ ${variables}
         );
 
         const publicApiStylesJsonData: PublicApiStyles = {};
+        const publicApiStylesCssData: PublicApiStyles = {};
         for (const json of publicClassJsonFiles) {
           const parsed = JSON.parse(json) as PublicApiStyles;
           mergePublicApiStylesResults(publicApiStylesJsonData, parsed);
+          mergePublicApiStylesResultsForCss(publicApiStylesCssData, parsed);
         }
-        if (publicApiStylesJsonData.groups || publicApiStylesJsonData.styles) {
-          localTokens += generatePublicStylesCss(publicApiStylesJsonData);
+        if (publicApiStylesCssData.groups || publicApiStylesCssData.styles) {
+          localTokens += generatePublicStylesCss(publicApiStylesCssData);
         }
 
         localTokens = await addAssetsCss(
@@ -394,14 +397,16 @@ ${variables}
       }
 
       const publicApiStylesJsonData: PublicApiStyles = {};
+      const publicApiStylesCssData: PublicApiStyles = {};
       for (const json of publicClassJsonFiles) {
         const parsed = JSON.parse(json) as PublicApiStyles;
         mergePublicApiStylesResults(publicApiStylesJsonData, parsed);
+        mergePublicApiStylesResultsForCss(publicApiStylesCssData, parsed);
       }
-      if (publicApiStylesJsonData.groups || publicApiStylesJsonData.styles) {
+      if (publicApiStylesCssData.groups || publicApiStylesCssData.styles) {
         compositeFiles[publicApiFileName] =
           (compositeFiles[publicApiFileName] ?? '') +
-          generatePublicStylesCss(publicApiStylesJsonData);
+          generatePublicStylesCss(publicApiStylesCssData);
       }
 
       for (const fileName of Object.keys(compositeFiles)) {

--- a/src/plugins/build-style-dictionary-plugin.mts
+++ b/src/plugins/build-style-dictionary-plugin.mts
@@ -323,7 +323,7 @@ ${variables}
       if (id.includes('src/dev/tokens.css')) {
         const assetsBasePath = '/assets/';
 
-        const { tokenFiles, publicTokenCssFiles } =
+        const { tokenFiles, publicTokenCssFiles, publicClassJsonFiles } =
           await generateDictionaryFiles(tokenConfig, {
             assetsBasePath,
             selectorPrefix: '.local-dev-tokens',
@@ -334,6 +334,15 @@ ${variables}
           (acc, file) => acc + (file.output as string),
           '',
         );
+
+        const publicApiStylesJsonData: PublicApiStyles = {};
+        for (const json of publicClassJsonFiles) {
+          const parsed = JSON.parse(json) as PublicApiStyles;
+          mergePublicApiStylesResults(publicApiStylesJsonData, parsed);
+        }
+        if (publicApiStylesJsonData.groups || publicApiStylesJsonData.styles) {
+          localTokens += generatePublicStylesCss(publicApiStylesJsonData);
+        }
 
         localTokens = await addAssetsCss(
           tokenConfig,

--- a/src/plugins/build-style-dictionary-plugin.spec.mts
+++ b/src/plugins/build-style-dictionary-plugin.spec.mts
@@ -1572,6 +1572,142 @@ describe('buildStyleDictionaryPlugin', () => {
     );
   });
 
+  it('should include excludeFromDocs styles in CSS but not in the JSON output', async () => {
+    const tokenConfig: TokenConfig = {
+      rootPath: 'src/plugins/fixtures/',
+      projectName: 'skyux-brand-test',
+      tokenSets: [
+        {
+          name: 'rainbow',
+          selector: '.sky-theme-rainbow',
+          path: 'base-rainbow.json',
+          outputPath: 'rainbow.css',
+          referenceTokens: [
+            {
+              name: 'rainbow-colors',
+              path: 'rainbow-colors.json',
+            },
+          ],
+          publicTokens: [
+            {
+              name: 'public-colors',
+              path: 'public-colors.json',
+              docsPath: 'public-colors-docs.json',
+            },
+          ],
+          publicStyles: [
+            {
+              name: 'public-classes-with-excluded',
+              path: 'public-classes-with-excluded.json',
+            },
+          ],
+        },
+      ],
+    };
+
+    const expectedEmittedFiles: { fileName: string; source: string }[] = [
+      {
+        fileName: 'assets/scss/rainbow.css',
+        source: `.sky-theme-rainbow {
+  --rainbow-color-gray-1: #e2e3e7;
+  --rainbow-color-gray-2: #c0c2c5;
+  --rainbow-color-red-1: #fc0330;
+  --rainbow-color-red-2: #8a2538;
+  --rainbow-space-s: 10px;
+}
+.sky-theme-rainbow {
+  --sky-color-background-danger: var(--rainbow-color-gray-1);
+  --sky-color-text-default: var(--rainbow-color-red-1);
+}
+`,
+      },
+    ];
+
+    // Both styles (public and excludeFromDocs) should appear in the CSS.
+    const expectedEmittedPublicApiFile = {
+      source: `.sky-theme-rainbow {
+  /* The background color for danger elements. */
+  --sky-theme-color-background-danger: var(--sky-color-background-danger);
+  /* The default text color. */
+  --sky-theme-color-text-default: var(--sky-color-text-default);
+}
+.sky-theme-text-default {
+  color: var(--sky-theme-color-text-default);
+}
+.sky-theme-text-internal {
+  color: var(--sky-theme-color-text-default);
+}
+`,
+    };
+
+    // Only the public style (not the excludeFromDocs one) should appear in the JSON.
+    const expectedEmittedPublicApiStylesJsonFile = {
+      source: JSON.stringify(
+        {
+          styles: [
+            {
+              name: 'Default Text Color',
+              className: 'sky-theme-text-default',
+              description: 'Applies the default text color.',
+              properties: { color: 'var(--sky-theme-color-text-default)' },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    };
+
+    const expectedEmittedPublicApiJsonFile = {
+      source: JSON.stringify(
+        {
+          groups: [
+            {
+              groupName: 'Colors',
+              description: 'All color tokens.',
+              groups: [
+                {
+                  groupName: 'Text Colors',
+                  description: 'Text color tokens.',
+                  tokens: [
+                    {
+                      name: 'Default Text',
+                      customProperty: '--sky-theme-color-text-default',
+                      description: 'The default text color.',
+                      deprecatedCustomProperties: ['--old-text-color'],
+                    },
+                  ],
+                },
+                {
+                  groupName: 'Background Colors',
+                  description: 'Background color tokens.',
+                  tokens: [
+                    {
+                      name: 'Danger Background',
+                      customProperty: '--sky-theme-color-background-danger',
+                      description: 'The background color for danger elements.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    };
+
+    await validate(
+      tokenConfig,
+      expectedEmittedFiles,
+      undefined,
+      expectedEmittedPublicApiFile,
+      expectedEmittedPublicApiJsonFile,
+      expectedEmittedPublicApiStylesJsonFile,
+    );
+  });
+
   describe('transform', () => {
     async function callTransform(
       plugin: ReturnType<typeof buildStyleDictionaryPlugin>,
@@ -1627,6 +1763,47 @@ describe('buildStyleDictionaryPlugin', () => {
 
       expect(result).toContain('.sky-theme-text-default {');
       expect(result).toContain('color: var(--sky-theme-color-text-default);');
+    });
+
+    it('should include excludeFromDocs styles in the dev token output', async () => {
+      const tokenConfig: TokenConfig = {
+        rootPath: 'src/plugins/fixtures/',
+        projectName: 'skyux-brand-test',
+        tokenSets: [
+          {
+            name: 'rainbow',
+            selector: '.sky-theme-rainbow',
+            path: 'base-rainbow.json',
+            outputPath: 'rainbow.css',
+            referenceTokens: [
+              {
+                name: 'rainbow-colors',
+                path: 'rainbow-colors.json',
+              },
+            ],
+            publicTokens: [
+              {
+                name: 'public-colors',
+                path: 'public-colors.json',
+                docsPath: 'public-colors-docs.json',
+              },
+            ],
+            publicStyles: [
+              {
+                name: 'public-classes-with-excluded',
+                path: 'public-classes-with-excluded.json',
+              },
+            ],
+          },
+        ],
+      };
+
+      vi.spyOn(assetsUtils, 'generateAssetsCss').mockResolvedValue('');
+      const plugin = buildStyleDictionaryPlugin(tokenConfig);
+      const result = await callTransform(plugin, 'src/dev/tokens.css');
+
+      expect(result).toContain('.sky-theme-text-default {');
+      expect(result).toContain('.sky-theme-text-internal {');
     });
 
     it('should return undefined for non-token files', async () => {

--- a/src/plugins/build-style-dictionary-plugin.spec.mts
+++ b/src/plugins/build-style-dictionary-plugin.spec.mts
@@ -1571,4 +1571,83 @@ describe('buildStyleDictionaryPlugin', () => {
       'Token docs validation failed for "public-colors-text-only"',
     );
   });
+
+  describe('transform', () => {
+    async function callTransform(
+      plugin: ReturnType<typeof buildStyleDictionaryPlugin>,
+      id: string,
+    ): Promise<string | undefined> {
+      if (plugin.transform) {
+        return (
+          plugin.transform as (
+            code: string,
+            id: string,
+          ) => Promise<string | undefined>
+        ).call({ addWatchFile: () => undefined }, '', id);
+      }
+      return undefined;
+    }
+
+    it('should include public styles CSS in the dev token output', async () => {
+      const tokenConfig: TokenConfig = {
+        rootPath: 'src/plugins/fixtures/',
+        projectName: 'skyux-brand-test',
+        tokenSets: [
+          {
+            name: 'rainbow',
+            selector: '.sky-theme-rainbow',
+            path: 'base-rainbow.json',
+            outputPath: 'rainbow.css',
+            referenceTokens: [
+              {
+                name: 'rainbow-colors',
+                path: 'rainbow-colors.json',
+              },
+            ],
+            publicTokens: [
+              {
+                name: 'public-colors',
+                path: 'public-colors.json',
+                docsPath: 'public-colors-docs.json',
+              },
+            ],
+            publicStyles: [
+              {
+                name: 'public-classes-valid-refs',
+                path: 'public-classes-valid-refs.json',
+              },
+            ],
+          },
+        ],
+      };
+
+      vi.spyOn(assetsUtils, 'generateAssetsCss').mockResolvedValue('');
+      const plugin = buildStyleDictionaryPlugin(tokenConfig);
+      const result = await callTransform(plugin, 'src/dev/tokens.css');
+
+      expect(result).toContain('.sky-theme-text-default {');
+      expect(result).toContain('color: var(--sky-theme-color-text-default);');
+    });
+
+    it('should return undefined for non-token files', async () => {
+      const tokenConfig: TokenConfig = {
+        rootPath: 'src/plugins/fixtures/',
+        projectName: 'skyux-brand-test',
+        tokenSets: [
+          {
+            name: 'rainbow',
+            selector: '.sky-theme-rainbow',
+            path: 'base-rainbow.json',
+            outputPath: 'rainbow.css',
+            referenceTokens: [],
+          },
+        ],
+      };
+
+      const plugin = buildStyleDictionaryPlugin(tokenConfig);
+      const result = await callTransform(plugin, 'src/some-other-file.ts');
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/plugins/build-style-dictionary-plugin.spec.mts
+++ b/src/plugins/build-style-dictionary-plugin.spec.mts
@@ -753,10 +753,10 @@ describe('buildStyleDictionaryPlugin', () => {
     ];
 
     const expectedEmittedPublicApiFile = {
-      source: `.sky-theme-rainbow .sky-theme-margin-top-xs {
+      source: `.sky-theme-margin-top-xs {
   margin-top: 0.5rem;
 }
-.sky-theme-rainbow .sky-theme-margin-top-s {
+.sky-theme-margin-top-s {
   margin-top: 1rem;
 }
 `,
@@ -846,10 +846,10 @@ describe('buildStyleDictionaryPlugin', () => {
     ];
 
     const expectedEmittedPublicApiFile = {
-      source: `.sky-theme-rainbow .sky-theme-ungrouped {
+      source: `.sky-theme-ungrouped {
   display: block;
 }
-.sky-theme-rainbow .sky-theme-text-default {
+.sky-theme-text-default {
   color: black;
 }
 `,
@@ -998,7 +998,7 @@ describe('buildStyleDictionaryPlugin', () => {
   /* The default text color. */
   --sky-theme-color-text-default: var(--sky-color-text-default);
 }
-.sky-theme-rainbow .sky-theme-text-default {
+.sky-theme-text-default {
   color: var(--sky-theme-color-text-default);
 }
 `,
@@ -1122,16 +1122,13 @@ describe('buildStyleDictionaryPlugin', () => {
 
     // Both class sets emit their own CSS block into bundles/public-api.css; dedup only applies to the JSON.
     const expectedEmittedPublicApiFile = {
-      source: `.sky-theme-rainbow .sky-theme-margin-top-xs {
+      source: `.sky-theme-margin-top-xs {
   margin-top: 0.5rem;
 }
-.sky-theme-rainbow .sky-theme-margin-top-s {
+.sky-theme-margin-top-s {
   margin-top: 1rem;
 }
-.sky-theme-rainbow .sky-theme-margin-top-xs {
-  margin-top: 0.5rem;
-}
-.sky-theme-rainbow .sky-theme-margin-top-l {
+.sky-theme-margin-top-l {
   margin-top: 2rem;
 }
 `,
@@ -1242,7 +1239,7 @@ describe('buildStyleDictionaryPlugin', () => {
   /* The default text color. */
   --sky-theme-color-text-default: var(--sky-color-text-default);
 }
-.sky-theme-rainbow .sky-theme-text-default {
+.sky-theme-text-default {
   color: var(--sky-theme-color-text-default);
 }
 `,

--- a/src/plugins/fixtures/public-classes-with-excluded.json
+++ b/src/plugins/fixtures/public-classes-with-excluded.json
@@ -1,0 +1,21 @@
+{
+  "styles": [
+    {
+      "name": "Default Text Color",
+      "className": "sky-theme-text-default",
+      "description": "Applies the default text color.",
+      "properties": {
+        "color": "var(--sky-theme-color-text-default)"
+      }
+    },
+    {
+      "name": "Internal Text Color",
+      "className": "sky-theme-text-internal",
+      "description": "Internal use only.",
+      "properties": {
+        "color": "var(--sky-theme-color-text-default)"
+      },
+      "excludeFromDocs": true
+    }
+  ]
+}

--- a/src/plugins/shared/public-api-styles-utils.mts
+++ b/src/plugins/shared/public-api-styles-utils.mts
@@ -68,6 +68,20 @@ export function mergePublicApiStylesResults(
   }
 }
 
+export function mergePublicApiStylesResultsForCss(
+  target: PublicApiStyles,
+  source: PublicApiStyles,
+): void {
+  if (source.styles) {
+    target.styles ??= [];
+    mergeStyleArrays(target.styles, source.styles, true);
+  }
+  if (source.groups) {
+    target.groups ??= [];
+    mergePublicApiStyleGroupArrays(target.groups, source.groups, true);
+  }
+}
+
 function buildRule(
   selector: string,
   properties: Record<string, string>,
@@ -106,6 +120,7 @@ function collectGroupStyles(
 function mergePublicApiStyleGroupArrays(
   target: PublicApiStyleGroup[],
   source: PublicApiStyleGroup[],
+  includeExcluded = false,
 ): void {
   for (const srcGroup of source) {
     const existing = target.find((g) => g.name === srcGroup.name);
@@ -117,22 +132,30 @@ function mergePublicApiStyleGroupArrays(
       existing.demoMetadata ??= srcGroup.demoMetadata;
       if (srcGroup.styles) {
         existing.styles ??= [];
-        mergeStyleArrays(existing.styles, srcGroup.styles);
+        mergeStyleArrays(existing.styles, srcGroup.styles, includeExcluded);
       }
       if (srcGroup.groups) {
         existing.groups ??= [];
-        mergePublicApiStyleGroupArrays(existing.groups, srcGroup.groups);
+        mergePublicApiStyleGroupArrays(
+          existing.groups,
+          srcGroup.groups,
+          includeExcluded,
+        );
       }
     } else {
       const newGroup = { ...srcGroup };
       if (newGroup.styles) {
         const filteredStyles: PublicApiStyle[] = [];
-        mergeStyleArrays(filteredStyles, newGroup.styles);
+        mergeStyleArrays(filteredStyles, newGroup.styles, includeExcluded);
         newGroup.styles = filteredStyles;
       }
       if (newGroup.groups) {
         const filteredGroups: PublicApiStyleGroup[] = [];
-        mergePublicApiStyleGroupArrays(filteredGroups, newGroup.groups);
+        mergePublicApiStyleGroupArrays(
+          filteredGroups,
+          newGroup.groups,
+          includeExcluded,
+        );
         newGroup.groups = filteredGroups;
       }
       target.push(newGroup);
@@ -207,10 +230,11 @@ function stableStyleKey(style: PublicApiStyle): string {
 function mergeStyleArrays(
   target: PublicApiStyle[],
   source: PublicApiStyle[],
+  includeExcluded = false,
 ): void {
   for (const style of source) {
     if (
-      !style.excludeFromDocs &&
+      (includeExcluded || !style.excludeFromDocs) &&
       !target.some((c) => stableStyleKey(c) === stableStyleKey(style))
     ) {
       target.push(style);

--- a/src/plugins/shared/public-api-styles-utils.mts
+++ b/src/plugins/shared/public-api-styles-utils.mts
@@ -4,26 +4,26 @@ import { PublicApiStyles } from '../../types/public-api-styles.js';
 
 export function generatePublicStylesCss(
   publicApiStyles: PublicApiStyles,
-  selector: string,
 ): string {
   const styles = collectAllStyles(publicApiStyles);
   const lines: string[] = [];
+  const seen = new Set<string>();
 
   for (const style of styles) {
     if (style.className && style.properties) {
-      lines.push(`${selector} .${style.className} {`);
-      for (const [prop, value] of Object.entries(style.properties)) {
-        lines.push(`  ${prop}: ${value};`);
+      const rule = buildRule(`.${style.className}`, style.properties);
+      if (!seen.has(rule)) {
+        seen.add(rule);
+        lines.push(rule);
       }
-      lines.push('}');
     }
     if (style.selectors && style.selectors.length > 0 && style.properties) {
       for (const sel of style.selectors) {
-        lines.push(`${selector} ${sel} {`);
-        for (const [prop, value] of Object.entries(style.properties)) {
-          lines.push(`  ${prop}: ${value};`);
+        const rule = buildRule(sel, style.properties);
+        if (!seen.has(rule)) {
+          seen.add(rule);
+          lines.push(rule);
         }
-        lines.push('}');
       }
     }
   }
@@ -66,6 +66,16 @@ export function mergePublicApiStylesResults(
     target.groups ??= [];
     mergePublicApiStyleGroupArrays(target.groups, source.groups);
   }
+}
+
+function buildRule(
+  selector: string,
+  properties: Record<string, string>,
+): string {
+  const propLines = Object.entries(properties)
+    .map(([prop, value]) => `  ${prop}: ${value};`)
+    .join('\n');
+  return `${selector} {\n${propLines}\n}`;
 }
 
 function collectAllStyles(publicApiStyles: PublicApiStyles): PublicApiStyle[] {

--- a/src/plugins/shared/public-api-styles-utils.spec.mts
+++ b/src/plugins/shared/public-api-styles-utils.spec.mts
@@ -29,9 +29,9 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
     expect(css).toBe(
-      `.sky-theme .sky-theme-margin-top-xs {
+      `.sky-theme-margin-top-xs {
   margin-top: 0.5rem;
 }
 `,
@@ -49,9 +49,9 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
     expect(css).not.toContain('/*');
-    expect(css).toContain('.sky-theme .sky-theme-foo {');
+    expect(css).toContain('.sky-theme-foo {');
   });
 
   it('should generate flat CSS for grouped classes', () => {
@@ -70,10 +70,10 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
     expect(css).not.toContain('Margin top');
     expect(css).not.toContain('Top margins');
-    expect(css).toContain('.sky-theme .sky-theme-margin-top-xs {');
+    expect(css).toContain('.sky-theme-margin-top-xs {');
   });
 
   it('should flatten nested subgroups', () => {
@@ -96,13 +96,13 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
     expect(css).not.toContain('/*');
-    expect(css).toContain('.sky-theme .sky-theme-text-default {');
+    expect(css).toContain('.sky-theme-text-default {');
   });
 
   it('should handle empty input', () => {
-    const css = generatePublicStylesCss({}, '.sky-theme');
+    const css = generatePublicStylesCss({});
     expect(css).toBe('');
   });
 
@@ -120,11 +120,11 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
     expect(css).not.toContain('Old Class');
     expect(css).not.toContain('undefined');
-    expect(css).toContain('.sky-theme .sky-theme-margin-top-xs {');
+    expect(css).toContain('.sky-theme-margin-top-xs {');
   });
 
   it('should skip obsolete-only classes that have no className or properties', () => {
@@ -141,11 +141,11 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
     expect(css).not.toContain('Removed Class');
     expect(css).not.toContain('undefined');
-    expect(css).toContain('.sky-theme .sky-theme-margin-top-xs {');
+    expect(css).toContain('.sky-theme-margin-top-xs {');
   });
 
   it('should skip deprecated-only classes in groups', () => {
@@ -167,10 +167,10 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
     expect(css).not.toContain('undefined');
-    expect(css).toContain('.sky-theme .sky-theme-margin-top-xs {');
+    expect(css).toContain('.sky-theme-margin-top-xs {');
   });
 
   it('should skip selectors-only entries when no properties present', () => {
@@ -184,11 +184,11 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
     expect(css).not.toContain('button');
     expect(css).not.toContain('undefined');
-    expect(css).toContain('.sky-theme .sky-theme-margin-top-xs {');
+    expect(css).toContain('.sky-theme-margin-top-xs {');
   });
 
   it('should generate CSS for both className and selectors when both are present', () => {
@@ -202,10 +202,10 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
-    expect(css).toContain('.sky-theme .sky-theme-text-default {');
-    expect(css).toContain('.sky-theme p {');
+    expect(css).toContain('.sky-theme-text-default {');
+    expect(css).toContain('p {');
   });
 
   it('should generate CSS for each selector in the selectors list', () => {
@@ -219,11 +219,11 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
 
-    expect(css).toContain('.sky-theme h1 {');
-    expect(css).toContain('.sky-theme h2 {');
-    expect(css).toContain('.sky-theme h3 {');
+    expect(css).toContain('h1 {');
+    expect(css).toContain('h2 {');
+    expect(css).toContain('h3 {');
   });
 
   it('should render both top-level classes and group classes', () => {
@@ -247,9 +247,9 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
-    expect(css).toContain('.sky-theme .sky-theme-ungrouped {');
-    expect(css).toContain('.sky-theme .sky-theme-text-default {');
+    const css = generatePublicStylesCss(input);
+    expect(css).toContain('.sky-theme-ungrouped {');
+    expect(css).toContain('.sky-theme-text-default {');
     expect(css).not.toContain('/*');
   });
 
@@ -267,12 +267,12 @@ describe('generatePublicStylesCss', () => {
       ],
     };
 
-    const css = generatePublicStylesCss(input, '.sky-theme');
+    const css = generatePublicStylesCss(input);
     expect(css).toBe(
-      `.sky-theme .sky-theme-a {
+      `.sky-theme-a {
   display: block;
 }
-.sky-theme .sky-theme-b {
+.sky-theme-b {
   display: flex;
 }
 `,

--- a/src/plugins/shared/public-api-styles-utils.spec.mts
+++ b/src/plugins/shared/public-api-styles-utils.spec.mts
@@ -6,6 +6,7 @@ import type { PublicApiStyles } from '../../types/public-api-styles.js';
 import {
   generatePublicStylesCss,
   mergePublicApiStylesResults,
+  mergePublicApiStylesResultsForCss,
   validatePublicStylesCssProperties,
 } from './public-api-styles-utils.mjs';
 
@@ -899,5 +900,91 @@ describe('mergePublicApiStylesResults', () => {
     mergePublicApiStylesResults(target, source);
 
     expect(target.groups![0].demoMetadata).toEqual({ background: 'light' });
+  });
+});
+
+describe('mergePublicApiStylesResultsForCss', () => {
+  it('should include styles flagged with excludeFromDocs', () => {
+    const target: PublicApiStyles = {};
+    const source: PublicApiStyles = {
+      styles: [
+        makeStyle({
+          className: 'sky-theme-visible',
+          properties: { display: 'block' },
+        }),
+        makeStyle({
+          className: 'sky-theme-hidden',
+          properties: { display: 'none' },
+          excludeFromDocs: true,
+        }),
+      ],
+    };
+
+    mergePublicApiStylesResultsForCss(target, source);
+
+    expect(target.styles).toHaveLength(2);
+    expect(target.styles!.map((s) => s.className)).toEqual([
+      'sky-theme-visible',
+      'sky-theme-hidden',
+    ]);
+  });
+
+  it('should include excludeFromDocs styles inside groups', () => {
+    const target: PublicApiStyles = {};
+    const source: PublicApiStyles = {
+      groups: [
+        {
+          name: 'Spacing',
+          styles: [
+            makeStyle({
+              className: 'sky-theme-xs',
+              properties: { 'margin-top': '0.5rem' },
+            }),
+            makeStyle({
+              className: 'sky-theme-internal',
+              properties: { 'margin-top': '1rem' },
+              excludeFromDocs: true,
+            }),
+          ],
+        },
+      ],
+    };
+
+    mergePublicApiStylesResultsForCss(target, source);
+
+    expect(target.groups![0].styles).toHaveLength(2);
+    expect(target.groups![0].styles!.map((s) => s.className)).toEqual([
+      'sky-theme-xs',
+      'sky-theme-internal',
+    ]);
+  });
+
+  it('should still deduplicate by className', () => {
+    const target: PublicApiStyles = {
+      styles: [
+        makeStyle({
+          className: 'sky-theme-a',
+          properties: { display: 'block' },
+        }),
+      ],
+    };
+    const source: PublicApiStyles = {
+      styles: [
+        makeStyle({
+          className: 'sky-theme-a',
+          properties: { display: 'none' },
+        }),
+        makeStyle({
+          className: 'sky-theme-b',
+          properties: { display: 'flex' },
+        }),
+      ],
+    };
+
+    mergePublicApiStylesResultsForCss(target, source);
+
+    expect(target.styles).toHaveLength(2);
+    expect(target.styles![0].properties).toEqual({ display: 'block' });
+    expect(target.styles![1].className).toBe('sky-theme-b');
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated package to version 4.0.0.

* **Breaking Changes**
  * Public API classes are no longer namespaced.
  * Identical class definitions are now automatically deduplicated.
  * CSS selectors are now flattened (namespace prefix removed).

* **Improvements**
  * Generated CSS output is deduplicated to remove redundant rules.
  * Styles marked "exclude from docs" are now emitted into CSS but omitted from public API JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->