### PR TITLE
fix: make base and reference tokens optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.1 (2026-04-22)
+- Support token sets without base or reference tokens. [#12](https://github.com/blackbaud/skyux-branding-builder/pull/12)
+
+
+
 # 5.0.0 (2026-04-09)
 
 ## BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-branding-builder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-branding-builder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "style dictionary builder for design tokens",
   "main": "index.js",
   "type": "module",

--- a/src/plugins/build-style-dictionary-plugin.mts
+++ b/src/plugins/build-style-dictionary-plugin.mts
@@ -63,19 +63,27 @@ async function generateDictionaryFiles(
       const publicTokenJsonFiles: string[] = [];
       const publicClassJsonFiles: string[] = [];
 
-      const tokenDictionary = await sd.extend(
-        getBaseDictionaryConfig(rootPath, tokenSet, {
-          ...skyOptions,
-          generateUrlAtProperties: true,
-        }),
-      );
+      if (tokenSet.path) {
+        const tokenDictionary = await sd.extend(
+          getBaseDictionaryConfig(rootPath, tokenSet, {
+            ...skyOptions,
+            generateUrlAtProperties: true,
+          }),
+        );
 
-      const sourceCssFiles: GeneratedFile[] =
-        await tokenDictionary.formatPlatform('css');
-      tokenFiles.push(...sourceCssFiles);
+        const sourceCssFiles: GeneratedFile[] =
+          await tokenDictionary.formatPlatform('css');
+        tokenFiles.push(...sourceCssFiles);
+      }
+
+      if (tokenSet.referenceTokens?.length && !tokenSet.path) {
+        throw new Error(
+          `Token set "${tokenSet.name}" has referenceTokens but no base path. A base path is required when referenceTokens are provided.`,
+        );
+      }
 
       const referenceTokenResults = await Promise.all(
-        tokenSet.referenceTokens.map(async (referenceTokenSet) => {
+        (tokenSet.referenceTokens ?? []).map(async (referenceTokenSet) => {
           const referenceTokenDictionary = await sd.extend(
             getReferenceDictionaryConfig(
               rootPath,
@@ -387,15 +395,23 @@ ${variables}
 
       const compositeFiles: Record<string, string> = {};
       const publicApiFileName = 'bundles/public-api.css';
+      const outputPathByName = new Map(
+        tokenConfig.tokenSets.map((ts) => [
+          ts.name,
+          ts.outputPath ?? `${ts.name}.css`,
+        ]),
+      );
 
       for (const file of tokenFiles) {
         if (file.destination) {
           const fileParts = file.destination.split('/');
-          const tokenSetType = fileParts[1];
-          const fileName = `bundles/${tokenSetType}.css`;
+          const tokenSetName = fileParts[1];
+          const outputFileName =
+            outputPathByName.get(tokenSetName) ?? `${tokenSetName}.css`;
+          const fileName = `bundles/${outputFileName}`;
           // For backwards compatibility with older versions of SKY UX; remove this in a future
           // breaking change.
-          const compatFileName = `assets/scss/${tokenSetType}.css`;
+          const compatFileName = `assets/scss/${outputFileName}`;
 
           const output = (file.output as string) ?? '';
           compositeFiles[fileName] = (compositeFiles[fileName] ?? '') + output;

--- a/src/plugins/build-style-dictionary-plugin.spec.mts
+++ b/src/plugins/build-style-dictionary-plugin.spec.mts
@@ -671,7 +671,6 @@ describe('buildStyleDictionaryPlugin', () => {
         {
           name: 'multiVal',
           selector: '.sky-theme-multi-val',
-          outputPath: 'multi-value-dimension.css',
           path: 'multi-value-dimension.json',
           referenceTokens: [],
         },
@@ -683,6 +682,40 @@ describe('buildStyleDictionaryPlugin', () => {
         fileName: 'assets/scss/multiVal.css',
         source: `.sky-theme-multi-val {
   --multiVal-maxWidth: 50ch, 40vw;
+}
+`,
+      },
+    ];
+
+    await validate(tokenConfig, expectedEmittedFiles);
+  });
+
+  it('should use outputPath as the emitted CSS file name when provided', async () => {
+    const tokenConfig: TokenConfig = {
+      rootPath: 'src/plugins/fixtures/',
+      projectName: 'skyux-brand-test',
+      tokenSets: [
+        {
+          name: 'zeroes',
+          selector: '.sky-theme-zero',
+          path: 'zeroes.json',
+          outputPath: 'custom-output.css',
+          referenceTokens: [],
+        },
+      ],
+    };
+
+    const expectedEmittedFiles: { fileName: string; source: string }[] = [
+      {
+        fileName: 'assets/scss/custom-output.css',
+        source: `.sky-theme-zero {
+  --zeroTest-space-1: 0rem;
+  --zeroTest-space-2: 0rem;
+  --zeroTest-space-3: 0rem;
+  --zeroTest-space-4: 0rem;
+  --zeroTest-space-5: 0rem;
+  --zeroTest-space-6: 0;
+  --zeroTest-space-7: #000000;
 }
 `,
       },
@@ -1606,6 +1639,31 @@ describe('buildStyleDictionaryPlugin', () => {
     );
   });
 
+  it('should throw when referenceTokens are provided without a base path', async () => {
+    const tokenConfig: TokenConfig = {
+      rootPath: 'src/plugins/fixtures/',
+      projectName: 'skyux-brand-test',
+      tokenSets: [
+        {
+          name: 'rainbow',
+          selector: '.sky-theme-rainbow',
+          referenceTokens: [
+            {
+              name: 'rainbow-colors',
+              path: 'rainbow-colors.json',
+            },
+          ],
+        },
+      ],
+    };
+    vi.spyOn(assetsUtils, 'generateAssetsCss').mockResolvedValue('');
+    const plugin = buildStyleDictionaryPlugin(tokenConfig);
+    const emitFileSpy = vi.fn();
+    await expect(callGenerateBundle(plugin, emitFileSpy)).rejects.toThrow(
+      'Token set "rainbow" has referenceTokens but no base path. A base path is required when referenceTokens are provided.',
+    );
+  });
+
   it('should include excludeFromDocs styles in CSS but not in the JSON output', async () => {
     const tokenConfig: TokenConfig = {
       rootPath: 'src/plugins/fixtures/',
@@ -1739,6 +1797,42 @@ describe('buildStyleDictionaryPlugin', () => {
       expectedEmittedPublicApiFile,
       expectedEmittedPublicApiJsonFile,
       expectedEmittedPublicApiStylesJsonFile,
+    );
+  });
+
+  it('should not emit CSS files when the token set has no base path', async () => {
+    const tokenConfig: TokenConfig = {
+      rootPath: 'src/plugins/fixtures/',
+      projectName: 'skyux-brand-test',
+      tokenSets: [
+        {
+          name: 'default',
+          selector: '.sky-theme-default',
+          referenceTokens: [],
+          publicTokens: [
+            {
+              name: 'public-colors-hardcoded',
+              path: 'public-colors-hardcoded.json',
+              docsPath: 'public-colors-hardcoded-docs.json',
+            },
+          ],
+        },
+      ],
+    };
+
+    vi.spyOn(assetsUtils, 'generateAssetsCss').mockResolvedValue('');
+    const plugin = buildStyleDictionaryPlugin(tokenConfig);
+    const emitFileSpy = vi.fn();
+    await callGenerateBundle(plugin, emitFileSpy);
+
+    expect(emitFileSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'bundles/default.css' }),
+    );
+    expect(emitFileSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'assets/scss/default.css' }),
+    );
+    expect(emitFileSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'bundles/public-api-tokens.json' }),
     );
   });
 

--- a/src/plugins/fixtures/public-colors-hardcoded-docs.json
+++ b/src/plugins/fixtures/public-colors-hardcoded-docs.json
@@ -1,0 +1,19 @@
+{
+  "groups": [
+    {
+      "groupName": "Colors",
+      "groups": [
+        {
+          "groupName": "Text Colors",
+          "tokens": [
+            {
+              "name": "Default Text",
+              "customProperty": "--sky-theme-color-text-default",
+              "description": "The default text color."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/plugins/fixtures/public-colors-hardcoded.json
+++ b/src/plugins/fixtures/public-colors-hardcoded.json
@@ -1,0 +1,22 @@
+{
+  "theme": {
+    "color": {
+      "$extensions": {
+        "com.blackbaud.developer.docs": { "groupName": "Colors" }
+      },
+      "text": {
+        "$extensions": {
+          "com.blackbaud.developer.docs": { "groupName": "Text Colors" }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "#000000",
+          "$description": "The default text color.",
+          "$extensions": {
+            "com.blackbaud.developer.docs": { "name": "Default Text" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/shared/style-dictionary-config.mts
+++ b/src/plugins/shared/style-dictionary-config.mts
@@ -109,10 +109,12 @@ export function getPublicDictionaryConfig(
   skyOptions: SkyTokenOptions,
 ): SkyStyleDictionaryConfig {
   const config = structuredClone(DEFAULT_SD_CONFIG);
-  config.source = [`${rootPath}${tokenSet.path}`];
+  if (tokenSet.path) {
+    config.source = [`${rootPath}${tokenSet.path}`];
+  }
   config.include = [
     `${rootPath}${publicTokenSet.path}`,
-    ...tokenSet.referenceTokens.map(
+    ...(tokenSet.referenceTokens ?? []).map(
       (referenceTokenSet) => `${rootPath}${referenceTokenSet.path}`,
     ),
   ];

--- a/src/types/token-set.ts
+++ b/src/types/token-set.ts
@@ -4,10 +4,10 @@ import { ReferenceTokenSet } from './reference-token-set.js';
 
 export type TokenSet = {
   name: string;
-  path: string;
+  path?: string;
   selector: string;
-  outputPath: string;
-  referenceTokens: ReferenceTokenSet[];
+  outputPath?: string;
+  referenceTokens?: ReferenceTokenSet[];
   publicTokens?: PublicTokenSet[];
   publicStyles?: PublicStyleSet[];
 };


### PR DESCRIPTION
- make the ouptutPath actually work if specified
- don't require output path--if not specfied, fallback to token set name
- don't require base path or reference tokens; this supports default theme which is hardcoded public tokens only
- if there are reference token sets, validate there is a base path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token sets can now be created without requiring base or reference tokens, providing greater flexibility in configuration.

* **Improvements**
  * Enhanced validation to prevent invalid configurations where reference tokens exist without a base path.
  * Improved handling of optional token set parameters for better configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->